### PR TITLE
build for Python 3.12 and Python 3.13

### DIFF
--- a/.github/workflows/maturin.yaml
+++ b/.github/workflows/maturin.yaml
@@ -3,8 +3,6 @@ name: Publish Release
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "*"
   release:
     types:
       - released

--- a/.github/workflows/maturin.yaml
+++ b/.github/workflows/maturin.yaml
@@ -24,13 +24,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
+        with:
+          python-version: "3.13"
+
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # ratchet:PyO3/maturin-action@v1
         with:
           working-directory: ./vrp-cli
           target: ${{ matrix.target }}
           sccache: "true"
-          args: --release --out dist -m Cargo.toml -i 3.12
+          args: --release --out dist -m Cargo.toml -i 3.12 -i 3.13
           manylinux: auto
 
       - name: Upload wheels
@@ -52,12 +56,17 @@ jobs:
           python-version: "3.12"
           architecture: "arm64"
 
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
+        with:
+          python-version: "3.13"
+          architecture: "arm64"
+
       - name: Build wheels
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # ratchet:PyO3/maturin-action@v1
         with:
           working-directory: ./vrp-cli
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -m Cargo.toml -i 3.12 -i 3.13
           sccache: "true"
 
       - name: Upload wheels


### PR DESCRIPTION
We currently seem to have been incidentally building for 3.13 on Macs already... this makes it more explicit