### PR TITLE
fix: correct pypi-publish workflow to use proper steps

### DIFF
--- a/.github/workflows/maturin.yaml
+++ b/.github/workflows/maturin.yaml
@@ -77,8 +77,9 @@ jobs:
 
   pypi-publish:
     name: Publish artifacts to Uptick's Pypi repo
-    if: startswith(github.ref, 'ref/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
+      id-token: write
       contents: write
     needs: [linux, macos]
     runs-on: ubuntu-latest
@@ -87,13 +88,23 @@ jobs:
         with:
           path: dist
           merge-multiple: true
-      - uses: uptick/actions/.github/workflows/ci.yaml@main # ratchet:exclude
-        secrets: inherit
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244 # ratchet:astral-sh/setup-uv@v7
         with:
-          pypi-dist: dist
-          uv: true
-          python: true
-          s3pypi-publish: true
+          version: "0.5.0"
+
+      - name: Setup and Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # ratchet:aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: arn:aws:iam::610829907584:role/default-github-actions-ci-role
+          role-session-name: vrp-pypi-publish
+          aws-region: us-east-1
+
+      - name: Build and Publish Package to S3Pypi
+        shell: bash
+        run: |
+          uvx s3pypi@2.0.1 upload dist/* --bucket s3pypi-610829907584-us-east-1
   gh-publish:
     name: Publish artifacts to GH
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The pypi-publish job was incorrectly trying to use a reusable workflow as a step action. This replaces it with the proper individual steps:
- Install uv
- Setup AWS credentials with OIDC
- Publish to S3Pypi using uvx

Also fixes typo in tag condition (ref/tags -> refs/tags) and adds required id-token permission for AWS OIDC authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)