### PR TITLE
fix(objectives): support depots with no location for hierarchical areas

### DIFF
--- a/vrp-pragmatic/src/format/problem/goal_reader.rs
+++ b/vrp-pragmatic/src/format/problem/goal_reader.rs
@@ -222,9 +222,15 @@ fn get_objective_feature_layer(
 }
 
 fn get_hierarchical_areas_feature(blocks: &ProblemBlocks, levels: usize) -> GenericResult<Feature> {
-    let locations = (0..blocks.transport.size()).collect::<Vec<_>>();
     let profile =
         blocks.fleet.profiles.first().cloned().ok_or_else(|| GenericError::from("should have at least one profile"))?;
+    let locations: Vec<_> = (0..blocks.transport.size())
+        .filter(|&loc| {
+            // Exclude locations with zero distance to all others (no real coordinates)
+            (0..blocks.transport.size())
+                .any(|other| other != loc && blocks.transport.distance_approx(&profile, loc, other) > 0.0)
+        })
+        .collect();
 
     let clusters = create_hierarchical_kmedoids(&locations, levels, {
         let transport = blocks.transport.clone();
@@ -236,6 +242,13 @@ fn get_hierarchical_areas_feature(blocks: &ProblemBlocks, levels: usize) -> Gene
         .set_transport_cost(blocks.transport.clone())
         .set_activity_cost(blocks.activity.clone())
         .build_minimize_distance()?;
+
+    // With too few distinct locations, clustering cannot produce a usable hierarchy
+    // (the first tier must have exactly two clusters), so fall back to the plain
+    // distance minimization the feature is based on.
+    if clusters.first().is_none_or(|clusters| clusters.len() != 2) {
+        return Ok(cost_feature);
+    }
 
     create_hierarchical_areas_feature(cost_feature, &clusters, {
         let transport = blocks.transport.clone();

--- a/vrp-pragmatic/tests/features/tour_shape/mod.rs
+++ b/vrp-pragmatic/tests/features/tour_shape/mod.rs
@@ -1,1 +1,2 @@
 mod basic_tour_compactness;
+mod small_hierarchical_areas;

--- a/vrp-pragmatic/tests/features/tour_shape/small_hierarchical_areas.rs
+++ b/vrp-pragmatic/tests/features/tour_shape/small_hierarchical_areas.rs
@@ -1,0 +1,26 @@
+use crate::format::problem::Objective::*;
+use crate::format::problem::*;
+use crate::helpers::*;
+
+#[test]
+fn can_handle_hierarchical_areas_with_too_few_locations() {
+    let problem = Problem {
+        plan: Plan {
+            jobs: vec![create_delivery_job("job1", (1., 0.)), create_delivery_job("job2", (2., 0.))],
+            ..create_empty_plan()
+        },
+        fleet: create_default_fleet(),
+        objectives: Some(vec![
+            MinimizeUnassigned { breaks: None },
+            HierarchicalAreas { levels: 3 },
+            MinimizeCost,
+        ]),
+        ..create_empty_problem()
+    };
+    let matrix = create_matrix_from_problem(&problem);
+
+    let solution = solve_with_metaheuristic(problem, Some(vec![matrix]));
+
+    assert!(solution.unassigned.is_none());
+    assert_eq!(solution.tours.len(), 1);
+}


### PR DESCRIPTION
We provide a start location of None if the technician doesn't have a depot set.

This is an issue as `technically` the VRP doesn't support VehicleShiftStarts with no start location, though it happily accepts it, and generates schedules with no depot location.

When using the `Hierarchical Areas` objective we run into an issue where it expects all locations to be valid, but we can incidentally include depots with no real location.

This filters those out to fix this objective erroring out.